### PR TITLE
Add `git_branch` variable to be sent as `ref` to Gitlab

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 type config struct {
 	PrivateToken  string `env:"private_token,required"`
 	RepositoryURL string `env:"repository_url,required"`
+	GitBranch     string `env:"git_branch,required"`
 	CommitHash    string `env:"commit_hash,required"`
 	APIURL        string `env:"api_base_url,required"`
 
@@ -54,6 +55,7 @@ func sendStatus(cfg config) error {
 	repo := url.PathEscape(getRepo(cfg.RepositoryURL))
 	form := url.Values{
 		"state":       {getState(cfg.Status)},
+		"ref":         {cfg.GitBranch},
 		"target_url":  {cfg.TargetURL},
 		"description": {getDescription(cfg.Description, cfg.Status)},
 		"context":     {cfg.Context},

--- a/step.yml
+++ b/step.yml
@@ -43,6 +43,17 @@ inputs:
       description: |-
         The URL for the repository we are working with
       is_required: true
+  - git_branch: "$BITRISE_GIT_BRANCH"
+    opts:
+      title: "Git branch"
+      summary: ""
+      description: |-
+        The branch for which the status needs to be reported
+
+        In case of a same commit hash on multiple branches
+        we need to let Gitlab know the _ref_ so the pipeline status
+        is updated correctly
+      is_required: true
   - commit_hash: "$BITRISE_GIT_COMMIT"
     opts:
       title: "Commit hash"


### PR DESCRIPTION
While adding Gitlab Status to our Bitrise workflow we had an issue where if the same commit (same hash) exists on multiple branches the status will be reported only on the default one since the `ref` param was not being sent and Gitlab would default to the defined default branch.

This PR adds the branch name as the `ref` param to the request being sent out by passing in the `$BITRISE_GIT_BRANCH`.

