### PR TITLE
Add coverage field

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"strconv"
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-tools/go-steputils/stepconf"

--- a/main.go
+++ b/main.go
@@ -60,11 +60,12 @@ func sendStatus(cfg config) error {
 		"context":     {cfg.Context},
 	}
 	
-	// TODO: add in main a check for coverage to be a float (cast from string to float and check error)
 	coverage := cfg.Coverage
 	
-	if coverage != "" {
-		form.Add("coverage", coverage)
+	if _, err := strconv.ParseFloat(coverage, 32); err == nil {
+	    form.Add("coverage", coverage)
+	} else {
+		log.Warnf("Coverage is not a representation of a floting point number: it will not be sent.")
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,8 @@ func sendStatus(cfg config) error {
 	if _, err := strconv.ParseFloat(coverage, 32); err == nil {
 	    form.Add("coverage", coverage)
 	} else {
-		log.Warnf("Coverage is not a representation of a floting point number: it will not be sent.")
+		log.Warnf("Coverage is not a representation of a floting point number: setting it to 0.0.")
+		form.Add("coverage", 0.0)
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)

--- a/main.go
+++ b/main.go
@@ -67,7 +67,7 @@ func sendStatus(cfg config) error {
 	    form.Add("coverage", coverage)
 	} else {
 		log.Warnf("Coverage is not a representation of a floting point number: setting it to 0.0.")
-		form.Add("coverage", 0.0)
+		form.Add("coverage", "0.0")
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ type config struct {
 	TargetURL   string `env:"target_url"`
 	Context     string `env:"context"`
 	Description string `env:"description"`
+	Coverage    string `env:"coverage"`
 }
 
 // getRepo parses the repository from a url. Possible url formats:
@@ -57,6 +58,13 @@ func sendStatus(cfg config) error {
 		"target_url":  {cfg.TargetURL},
 		"description": {getDescription(cfg.Description, cfg.Status)},
 		"context":     {cfg.Context},
+	}
+	
+	// TODO: add in main a check for coverage to be a float (cast from string to float and check error)
+	coverage := cfg.Coverage
+	
+	if coverage != "" {
+		form.Add("coverage", coverage)
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)

--- a/main.go
+++ b/main.go
@@ -70,7 +70,6 @@ func sendStatus(cfg config) error {
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)
-	log.Warnf("URL: %s", url)
 	req, err := http.NewRequest("POST", url, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -70,6 +70,7 @@ func sendStatus(cfg config) error {
 	}
 
 	url := fmt.Sprintf("%s/projects/%s/statuses/%s", cfg.APIURL, repo, cfg.CommitHash)
+	log.Warnf("URL: %s", url)
 	req, err := http.NewRequest("POST", url, strings.NewReader(form.Encode()))
 	if err != nil {
 		return err

--- a/step.yml
+++ b/step.yml
@@ -90,3 +90,11 @@ inputs:
         The short description of the status.
 
         If left empty, it will be the status of the build.
+  - coverage:
+    opts:
+      title: "Coverage"
+      summary: "Test coverage"
+      description: |-
+        The test coverage. 
+		
+		Must be a representation of a floating number. If not, it will be discarded.

--- a/step.yml
+++ b/step.yml
@@ -96,5 +96,5 @@ inputs:
       summary: "Test coverage"
       description: |-
         The test coverage. 
-		
-		Must be a representation of a floating number. If not, it will be discarded.
+        
+        Must be a representation of a floating number. If not, it will be discarded.


### PR DESCRIPTION
Add the possibility to send the test coverage to the GitLab instance. 
Test coverage must be a float, otherwise it is discarded.
The value can be calculated in a previous step and saved in an environment variable that then can be used in this step.
