### PR TITLE
Add support for repository URLs starting with ssh://

### DIFF
--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ type config struct {
 // - https://hostname/owner/repository.git
 // - git@hostname:owner/repository.git
 func getRepo(url string) string {
-	url = strings.TrimPrefix(strings.TrimPrefix(url, "https://"), "git@")
+	url = strings.TrimPrefix(strings.TrimPrefix(strings.TrimPrefix(url, "ssh://"), "https://"), "git@")
 	return url[strings.IndexAny(url, ":/")+1 : strings.Index(url, ".git")]
 }
 


### PR DESCRIPTION
The step failed because my repo URL started with `ssh://` because we use a custom SSH port and Bitrise doesn't support that without that prefix.