### PR TITLE
Fix the missing content-type header in the request

### DIFF
--- a/main.go
+++ b/main.go
@@ -77,6 +77,7 @@ func sendStatus(cfg config) error {
 		return err
 	}
 	req.Header.Add("PRIVATE-TOKEN", cfg.PrivateToken)
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Overview

The `content-type` header was missing in the API request. The step failed with an exception.

Issue report: #28 